### PR TITLE
Add Job.endAt computation, cache EXTRA_DECIMALS and fix build

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,7 +4,7 @@ enum RequestState {
   COMPLETED
 }
 
-type Job @entity {
+type Job @entity(immutable: false) {
   id: ID!
   metadata: String!
   owner: Bytes!
@@ -15,12 +15,13 @@ type Job @entity {
   totalDeposit: BigInt!
   refund: BigInt! # only updated on job close
   createdAt: BigInt!
+  endAt: BigInt!
   rateRevisionHistory: [ReviseRateRequest!]! @derivedFrom(field: "job")
   settlementHistory: [SettlementHistory!]! @derivedFrom(field: "job")
   depositHistory: [DepositHistory!]! @derivedFrom(field: "job")
 }
 
-type SettlementHistory @entity {
+type SettlementHistory @entity(immutable: true) {
   id: ID!
   job: Job!
   timestamp: BigInt!
@@ -28,7 +29,7 @@ type SettlementHistory @entity {
   txHash: Bytes!
 }
 
-type DepositHistory @entity {
+type DepositHistory @entity(immutable: true) {
   id: ID!
   job: Job!
   timestamp: BigInt!
@@ -37,7 +38,7 @@ type DepositHistory @entity {
   txHash: Bytes!
 }
 
-type ReviseRateRequest @entity {
+type ReviseRateRequest @entity(immutable: false) {
   id: ID!
   job: Job!
   updatesAt: BigInt!
@@ -45,13 +46,19 @@ type ReviseRateRequest @entity {
   value: BigInt!
 }
 
-type Provider @entity {
+type Provider @entity(immutable: false) {
   id: ID! #id same as owner address
   cp: String
   live: Boolean
 }
 
-type LockTime @entity {
+type LockTime @entity(immutable: false) {
+  id: ID!
+  value: BigInt!
+}
+
+# Config to store EXTRA_DECIMALS (global values)
+type Config @entity(immutable: false) {
   id: ID!
   value: BigInt!
 }

--- a/src/MarketV1.ts
+++ b/src/MarketV1.ts
@@ -1,4 +1,7 @@
 import {
+    MarketV1 as MarketV1Contract,
+    AdminChanged,
+    BeaconUpgraded,
     JobOpened,
     JobSettled,
     JobClosed,
@@ -14,11 +17,19 @@ import {
     LockWaitTimeUpdated,
 } from "../generated/MarketV1/MarketV1";
 
-import { BigInt } from "@graphprotocol/graph-ts/common/numbers";
-import { Job, SettlementHistory, DepositHistory, Provider, ReviseRateRequest, LockTime } from "../generated/schema";
+import { BigInt, Address } from "@graphprotocol/graph-ts";
+import { Job, SettlementHistory, DepositHistory, Provider, ReviseRateRequest, LockTime, Config } from "../generated/schema";
 import { log, store } from "@graphprotocol/graph-ts";
 
 export const FEE_REVISE_LOCK_SELECTOR: string = "0xbb00c34f1a27e23493f1bd516e88ec0af9b091cc990f207e765f5bd5af012243";
+
+export function handleAdminChanged(event: AdminChanged): void {
+    
+}
+
+export function handleBeaconUpgraded(event: BeaconUpgraded): void {
+ 
+}
 
 export function handleJobOpened(event: JobOpened): void {
     const id = event.params.job.toHex();
@@ -37,6 +48,7 @@ export function handleJobOpened(event: JobOpened): void {
     job.totalDeposit = event.params.balance;
     job.refund = BigInt.zero();
     job.createdAt = event.params.timestamp;
+    job.endAt = computeEndAt(job, event.address, event.block.timestamp);
 
     job.save();
 
@@ -64,6 +76,7 @@ export function handleJobDeposited(event: JobDeposited): void {
     }
     job.balance = job.balance.plus(event.params.amount);
     job.totalDeposit = job.totalDeposit.plus(event.params.amount);
+    job.endAt = computeEndAt(job, event.address, event.block.timestamp);
     job.save();
 
     const depositId = id + event.block.timestamp.toString() + "deposit";
@@ -104,11 +117,12 @@ export function handleJobClosed(event: JobClosed): void {
 
     job.refund = job.balance;
     job.balance = BigInt.zero();
+    job.endAt = event.block.timestamp;
     job.save();
 
 }
 
-export function handleJobReviseRateInitiated(event: JobReviseRateInitiated): void {
+export function handleJobRevisedRateInitiated(event: JobReviseRateInitiated): void {
     const id = event.params.job.toHex();
     let request = ReviseRateRequest.load(id);
 
@@ -131,7 +145,7 @@ export function handleJobReviseRateInitiated(event: JobReviseRateInitiated): voi
     request.save();
 }
 
-export function handleJobReviseRateCancelled(event: JobReviseRateCancelled): void {
+export function handleJobRevisedRateCancelled(event: JobReviseRateCancelled): void {
     const id = event.params.job.toHex();
     let request = ReviseRateRequest.load(id);
 
@@ -144,7 +158,7 @@ export function handleJobReviseRateCancelled(event: JobReviseRateCancelled): voi
     request.save();
 }
 
-export function handleJobReviseRateFinalized(event: JobReviseRateFinalized): void {
+export function handleJobRevisedRateFinalized(event: JobReviseRateFinalized): void {
     const id = event.params.job.toHex();
 
     let request = ReviseRateRequest.load(id);
@@ -164,6 +178,7 @@ export function handleJobReviseRateFinalized(event: JobReviseRateFinalized): voi
     }
 
     job.rate = event.params.newRate;
+    job.endAt = computeEndAt(job, event.address, event.block.timestamp);
     job.save();
 }
 
@@ -183,6 +198,7 @@ export function handleJobSettled(event: JobSettled): void {
     }
 
     job.lastSettled = event.block.timestamp;
+    job.endAt = computeEndAt(job, event.address, event.block.timestamp);
     job.save();
 
     let settlementId = id + event.block.timestamp.toString();
@@ -212,6 +228,7 @@ export function handleJobWithdrew(event: JobWithdrew): void {
     const amount = event.params.amount;
     job.balance = job.balance.minus(amount);
     job.totalDeposit = job.totalDeposit.minus(amount);
+    job.endAt = computeEndAt(job, event.address, event.block.timestamp);
     job.save();
 
     const withdrawId = id + event.block.timestamp.toString() + "withdraw";
@@ -283,4 +300,71 @@ export function handleLockWaitTimeUpdated(event: LockWaitTimeUpdated): void {
     lockTime.id = id;
     lockTime.value = event.params.updatedLockTime;
     lockTime.save();
+}
+
+/*
+ * Compute the expected insolvency end timestamp for a job using on-chain EXTRA_DECIMALS.
+ * Translated from CP's insolvency_duration logic:
+ * - if rate == 0 => duration 0 (endAt = now)
+ * - else: seconds = (balance * 10^extra_decimals / rate) - 300 - (now - lastSettled)
+ */
+function computeEndAt(job: Job, contractAddress: Address, now: BigInt): BigInt {
+    const extraDecimalsI32 = getExtraDecimals(contractAddress);
+
+    if (job.rate.equals(BigInt.zero())) {
+        return now;
+    }
+
+    const pow = pow10(extraDecimalsI32);
+
+    const numerator = job.balance.times(pow);
+    const secs = numerator.div(job.rate);
+    const margin = BigInt.fromI32(300);
+
+    const secsAfterMargin = secs.gt(margin) ? secs.minus(margin) : BigInt.zero();
+    let elapsed = BigInt.zero();
+    if (now.gt(job.lastSettled)) {
+        elapsed = now.minus(job.lastSettled);
+    }
+
+    const remaining = secsAfterMargin.gt(elapsed) ? secsAfterMargin.minus(elapsed) : BigInt.zero();
+
+    return now.plus(remaining);
+}
+
+function getExtraDecimals(contractAddress: Address): i32 {
+    // try cache first
+    let cfg = Config.load("EXTRA_DECIMALS");
+    if (cfg) {
+        return cfg.value.toI32();
+    }
+
+    const contract = MarketV1Contract.bind(contractAddress);
+    const tryExtra = contract.try_EXTRA_DECIMALS();
+    let extra: i32 = 12;
+    if (tryExtra.reverted) {
+        return extra;
+    }
+
+    const extraBig = tryExtra.value;
+    if (extraBig.isI32()) {
+        extra = extraBig.toI32();
+        if (extra < 0) extra = 0;
+    }
+
+    // persist
+    let newCfg = new Config("EXTRA_DECIMALS");
+    newCfg.value = BigInt.fromI32(extra);
+    newCfg.save();
+
+    return extra;
+}
+
+function pow10(exp: i32): BigInt {
+    let result = BigInt.fromI32(1);
+    const base = BigInt.fromI32(10);
+    for (let i = 0; i < exp; i++) {
+        result = result.times(base);
+    }
+    return result;
 }

--- a/src/MarketV1.ts
+++ b/src/MarketV1.ts
@@ -122,7 +122,7 @@ export function handleJobClosed(event: JobClosed): void {
 
 }
 
-export function handleJobRevisedRateInitiated(event: JobReviseRateInitiated): void {
+export function handleJobReviseRateInitiated(event: JobReviseRateInitiated): void {
     const id = event.params.job.toHex();
     let request = ReviseRateRequest.load(id);
 
@@ -145,7 +145,7 @@ export function handleJobRevisedRateInitiated(event: JobReviseRateInitiated): vo
     request.save();
 }
 
-export function handleJobRevisedRateCancelled(event: JobReviseRateCancelled): void {
+export function handleJobReviseRateCancelled(event: JobReviseRateCancelled): void {
     const id = event.params.job.toHex();
     let request = ReviseRateRequest.load(id);
 
@@ -158,7 +158,7 @@ export function handleJobRevisedRateCancelled(event: JobReviseRateCancelled): vo
     request.save();
 }
 
-export function handleJobRevisedRateFinalized(event: JobReviseRateFinalized): void {
+export function handleJobReviseRateFinalized(event: JobReviseRateFinalized): void {
     const id = event.params.job.toHex();
 
     let request = ReviseRateRequest.load(id);

--- a/src/MarketV1.ts
+++ b/src/MarketV1.ts
@@ -198,6 +198,7 @@ export function handleJobSettled(event: JobSettled): void {
     }
 
     job.lastSettled = event.block.timestamp;
+    // NOTE: The end time should not change ideally in this case, added for future-proofing 
     job.endAt = computeEndAt(job, event.address, event.block.timestamp);
     job.save();
 

--- a/subgraph-bsc.yaml
+++ b/subgraph-bsc.yaml
@@ -27,9 +27,9 @@ dataSources:
             address,uint256,uint256,uint256)
           handler: handleJobOpened
         - event: JobReviseRateInitiated(indexed bytes32,uint256)
-          handler: handleJobRevisedRateInitiated
+          handler: handleJobReviseRateInitiated
         - event: JobReviseRateCancelled(indexed bytes32)
-          handler: handleJobRevisedRateCancelled
+          handler: handleJobReviseRateCancelled
         - event: JobReviseRateFinalized(indexed bytes32,uint256)
           handler: handleJobReviseRateFinalized
         - event: JobSettled(indexed bytes32,uint256,uint256)

--- a/subgraph-bsc.yaml
+++ b/subgraph-bsc.yaml
@@ -27,9 +27,9 @@ dataSources:
             address,uint256,uint256,uint256)
           handler: handleJobOpened
         - event: JobReviseRateInitiated(indexed bytes32,uint256)
-          handler: handleJobReviseRateInitiated
+          handler: handleJobRevisedRateInitiated
         - event: JobReviseRateCancelled(indexed bytes32)
-          handler: handleJobReviseRateCancelled
+          handler: handleJobRevisedRateCancelled
         - event: JobReviseRateFinalized(indexed bytes32,uint256)
           handler: handleJobReviseRateFinalized
         - event: JobSettled(indexed bytes32,uint256,uint256)


### PR DESCRIPTION
* Update schema entity directives based on the latest The Graph version: mark mutable entities with `@entity(immutable: false)` and keep append-only histories immutable
* Add **Config** entity to cache on-chain EXTRA_DECIMALS
* Implement `getExtraDecimals` with clamping & persistence to avoid repeated on-chain reads
* Implement `computeEndAt` (insolvency duration) helper; wire into relevant handlers
* Update `*.yaml`'s to point to correct handler implementation and ABI in the project structure